### PR TITLE
fix: sort all-day and timed calendar events chronologically

### DIFF
--- a/_plugins/event_sort_key.rb
+++ b/_plugins/event_sort_key.rb
@@ -1,0 +1,7 @@
+Jekyll::Hooks.register :site, :pre_render do |site|
+  site.pages.each do |page|
+    event = page.data['event']
+    next unless event && event['start']
+    event['sort_key'] = (event['start']['dateTime'] || event['start']['date']).to_s
+  end
+end

--- a/calendar.md
+++ b/calendar.md
@@ -25,8 +25,8 @@ navbarText: Palo Alto, CA
   {% endif %}
 {% endfor %}
 
-{% assign upcoming = upcoming | sort: 'event.start.dateTime' %}
-{% assign past = past | sort: 'event.start.dateTime' | reverse %}
+{% assign upcoming = upcoming | sort: 'event.sort_key' %}
+{% assign past = past | sort: 'event.sort_key' | reverse %}
 
 <!-- Upcoming -->
 <section class="mx-auto max-w-6xl px-4 py-10">


### PR DESCRIPTION
## Summary

- The calendar page sorted by `event.start.dateTime`, which is nil for all-day Google Calendar events — causing them to cluster at the top of Upcoming and push the nearest timed events (next pack meetings, etc.) below events a year out.
- Added `_plugins/event_sort_key.rb` — a `:pre_render` hook that sets a stringified ISO `event.sort_key` falling back to `event.start.date`.
- Updated `calendar.md` to sort upcoming/past by `event.sort_key`, producing a single chronological list regardless of event type.

## Test plan

- [ ] Verify the deployed Cloudflare Pages build shows `/calendar/` with upcoming events in strict chronological order, starting with the next upcoming event.
- [ ] Confirm all-day events (e.g. Arrowpalooza, Fall Camping Trip) interleave correctly with timed events (e.g. Lion Den Meeting, Blue & Gold Banquet).
- [ ] Confirm Past Events still render in reverse chronological order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)