### PR TITLE
fix: sort homepage Coming Up events chronologically

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ navbarText: Palo Alto, CA
     {%- endif -%}
   {%- endif -%}
 {%- endfor -%}
-{%- assign upcoming = upcoming | sort: 'event.start.dateTime' -%}
+{%- assign upcoming = upcoming | sort: 'event.sort_key' -%}
 
 <section class="pt-2 pb-8 bg-slate-50">
   <div class="max-w-6xl px-4 mx-auto">


### PR DESCRIPTION
## Summary

- Follow-up to #15: the homepage `Coming Up` cards had the same sort bug — sorting by `event.start.dateTime` left all-day events clustered above timed events, so the two highlighted cards weren't the next upcoming pack events.
- Switched the sort to `event.sort_key` (the normalized ISO string added in #15) so all event types interleave in strict chronological order.

## Test plan

- [ ] Verify `pack57paloalto.com/` `Coming Up` section highlights the two nearest upcoming events regardless of all-day vs timed.
- [ ] Confirm the "More Upcoming Events" list on the third card continues in chronological order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)