### PR TITLE
feat: replace calendar list with interactive FullCalendar view

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,32 +36,38 @@ plugins:
 gcalendar:
   key_file: ./gcalendar-key.json
   calendars:
-    # public calendar - event pages
-    - id: c_dbd8c6d9e13e75097d2a4bb1e980c580cc9f07d2407f004db14eb0cfe5037bae@group.calendar.google.com
+    - name: 🐾 Pack 57
+      id: c_dbd8c6d9e13e75097d2a4bb1e980c580cc9f07d2407f004db14eb0cfe5037bae@group.calendar.google.com
       directory: events
       layout: event-public
       date_format: "%Y-%m-%d"
       look_ahead: 365
-    # lion den
-    - id: c_87e6640306451b91fd0e46b0611cc26768b64a586815bba5b5d956c60bbd544b@group.calendar.google.com
+    - name: 🦁 Lion Den
+      id: c_87e6640306451b91fd0e46b0611cc26768b64a586815bba5b5d956c60bbd544b@group.calendar.google.com
       directory: events
       layout: event-private
       date_format: "%Y-%m-%d"
       look_ahead: 365
-    # tiger den
-    - id: c_14f61c66ad0267f311c1ade24dd6d365960f801dd6b9bf55943bade450015fed@group.calendar.google.com
+    - name: 🐯 Tiger Den
+      id: c_14f61c66ad0267f311c1ade24dd6d365960f801dd6b9bf55943bade450015fed@group.calendar.google.com
       directory: events
       layout: event-private
       date_format: "%Y-%m-%d"
       look_ahead: 365
-    # bear den
-    - id: c_14dddfe86bf386af69d9cf03b888462ed7afd7be37ae0620a76b44171e7e091b@group.calendar.google.com
+    - name: 🐺 Wolf Den
+      id: c_914f7f15618f89b7095afab3acc7d1faca4277828d63c7c5d07d780a6ff9097e@group.calendar.google.com
       directory: events
       layout: event-private
       date_format: "%Y-%m-%d"
       look_ahead: 365
-    # wolf den
-    - id: c_23bf39238bebf6e1676802f8aed5c2f2e31fb28ec8c9428d08f2a3cf653fba91@group.calendar.google.com
+    - name: 🐻 Bear Den
+      id: c_14dddfe86bf386af69d9cf03b888462ed7afd7be37ae0620a76b44171e7e091b@group.calendar.google.com
+      directory: events
+      layout: event-private
+      date_format: "%Y-%m-%d"
+      look_ahead: 365
+    - name: 🏹 AoL Den
+      id: c_23bf39238bebf6e1676802f8aed5c2f2e31fb28ec8c9428d08f2a3cf653fba91@group.calendar.google.com
       directory: events
       layout: event-private
       date_format: "%Y-%m-%d"

--- a/_includes/calendar-widget.html
+++ b/_includes/calendar-widget.html
@@ -1,0 +1,102 @@
+{%- assign compact = include.compact | default: false -%}
+
+<div id="calendar" class="mt-6 bg-white rounded-2xl ring-1 ring-slate-200 p-3 md:p-5"></div>
+
+<style>
+  #calendar .fc .fc-toolbar-title { font-weight: 800; letter-spacing: 0.02em; }
+  #calendar .fc .fc-button { border-radius: 0.5rem; }
+  #calendar .fc .fc-button-primary { background:#1e3a8a; border-color:#1e3a8a; }
+  #calendar .fc .fc-button-primary:not(:disabled):hover { background:#1e40af; border-color:#1e40af; }
+  #calendar .fc .fc-button-primary:not(:disabled).fc-button-active { background:#0f172a; border-color:#0f172a; }
+  #calendar .fc a { text-decoration: none; }
+  #calendar .fc-daygrid-event { cursor: pointer; }
+  #calendar .fc-list-event { cursor: pointer; }
+  #calendar .fc-today-button { text-transform: capitalize; }
+
+  /* Month-view only: wrap event titles, clamp to 2 lines with ellipsis */
+  #calendar .fc-dayGridMonth-view .fc-daygrid-event { white-space: normal; align-items: flex-start; }
+  #calendar .fc-dayGridMonth-view .fc-daygrid-event .fc-event-title,
+  #calendar .fc-dayGridMonth-view .fc-daygrid-event .fc-event-title-container {
+    white-space: normal;
+    line-height: 1.2;
+  }
+  #calendar .fc-dayGridMonth-view .fc-daygrid-event .fc-event-title {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+  }
+  #calendar .fc-dayGridMonth-view .fc-daygrid-event .fc-event-time { flex-shrink: 0; margin-right: 0.25rem; }
+
+  /* Month-view only: highlight today's date number */
+  #calendar .fc-dayGridMonth-view .fc-day-today .fc-daygrid-day-number {
+    background: #ca8a04;
+    color: white;
+    font-weight: 800;
+    border-radius: 9999px;
+    padding: 0.15rem 0.5rem;
+    margin: 0.25rem;
+    display: inline-block;
+    min-width: 1.75rem;
+    text-align: center;
+  }
+</style>
+
+<script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js'></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var el = document.getElementById('calendar');
+    if (!el) return;
+    var isSmall = window.matchMedia('(max-width: 640px)').matches;
+    var compact = {{ compact | jsonify }};
+
+    var headerToolbar = compact
+      ? { left: 'prev,next', center: 'title', right: 'today' }
+      : { left: 'prev,next today', center: 'title', right: 'dayGridMonth,listYear' };
+
+    var cal = new FullCalendar.Calendar(el, {
+      initialView: isSmall ? 'listMonth' : 'dayGridMonth',
+      headerToolbar: headerToolbar,
+      views: {
+        listYear: { buttonText: 'List' }
+      },
+      buttonText: { today: 'Today', month: 'Month' },
+      height: 'auto',
+      firstDay: 0,
+      displayEventTime: true,
+      nowIndicator: true,
+      eventTimeFormat: { hour: 'numeric', minute: '2-digit', omitZeroMinute: true, meridiem: 'narrow' },
+      events: '{{ "/events.json" | relative_url }}',
+      eventClick: function (info) {
+        if (info.event.url) {
+          info.jsEvent.preventDefault();
+          window.location.href = info.event.url;
+        }
+      },
+      dayCellDidMount: function (arg) {
+        if (arg.view.type !== 'dayGridMonth') return;
+        if (arg.el.classList.contains('fc-day-past')) {
+          arg.el.style.setProperty('background-color', '#f1f5f9', 'important');
+          var num = arg.el.querySelector('.fc-daygrid-day-number');
+          if (num) {
+            num.style.setProperty('color', '#94a3b8', 'important');
+            num.style.opacity = '0.7';
+          }
+        }
+        if (arg.el.classList.contains('fc-day-today')) {
+          arg.el.style.setProperty('background-color', '#fef3c7', 'important');
+        }
+      },
+      eventDidMount: function (arg) {
+        if (arg.el.classList.contains('fc-event-past')) {
+          arg.el.style.opacity = '0.45';
+          arg.el.style.filter = 'saturate(0.6)';
+        }
+      }
+    });
+    cal.render();
+  });
+</script>

--- a/calendar.md
+++ b/calendar.md
@@ -3,103 +3,60 @@ layout: default
 title: Pack 57 Calendar
 permalink: /calendar/
 navbarText: Palo Alto, CA
+hideTitle: true
 ---
 
-
-<!-- Collect events -->
-{% assign now_epoch = site.time | date: "%s" %}
-{% assign upcoming = '' | split: '' %}
-{% assign past = '' | split: '' %}
-
-{% for p in site.pages %}
-  {% if p.url and p.event and p.url contains '/events/' %}
-    {% assign start_iso = p.event.start.dateTime | default: p.event.start.date %}
-    {% if start_iso %}
-      {% assign start_epoch = start_iso | date: "%s" %}
-      {% if start_epoch >= now_epoch %}
-        {% assign upcoming = upcoming | push: p %}
-      {% else %}
-        {% assign past = past | push: p %}
-      {% endif %}
-    {% endif %}
-  {% endif %}
-{% endfor %}
-
-{% assign upcoming = upcoming | sort: 'event.sort_key' %}
-{% assign past = past | sort: 'event.sort_key' | reverse %}
-
-<!-- Upcoming -->
 <section class="mx-auto max-w-6xl px-4 py-10">
-<h2 class="text-2xl md:text-3xl font-extrabold tracking-wide uppercase text-cub-blue">Upcoming Events</h2>
-{% if upcoming.size == 0 %}
-    <p class="mt-4 text-slate-600">No upcoming events found.</p>
-{% else %}
-    <div class="mt-6 divide-y divide-slate-200 rounded-2xl ring-1 ring-slate-200 bg-white">
-  {% for p in upcoming %}
-    {% assign ev = p.event %}
-    <article class="p-4 md:p-5 grid md:grid-cols-5 gap-3">
-      <p class="text-sm text-slate-500 md:col-span-1">
-        {{ ev.start.dateTime | default: ev.start.date | date: "%b %-d, %Y" }}
-      </p>
-      <div class="md:col-span-3">
-        <a href="{{ p.url | relative_url }}" class="font-semibold hover:underline">
-          {{ ev.summary | default: p.title }}
-        </a>
-        {% if ev.location %}
-          {% if p.layout contains "public" %}
-            <p class="text-sm text-slate-600 mt-0.5">{{ ev.location }}</p>
-          {% else %}
-            <p class="text-sm text-slate-600 mt-0.5">Location available in members calendar</p>
-          {% endif %}
-        {% endif %}
-      </div>
-      <div class="md:col-span-1 flex items-start md:justify-end">
-          <a href="{{ p.url }}" target="_blank" rel="noopener"
-             class="inline-flex items-center rounded-lg px-3 py-1.5 text-sm font-medium
-                    ring-1 ring-slate-300 hover:bg-slate-50">
-            View
-          </a>
-      </div>
-    </article>
-  {% endfor %}
-</div>
-{% endif %}
-</section>
-
-<!-- Past -->
-<section class="mx-auto max-w-6xl px-4 pb-16">
-<h2 class="text-2xl md:text-3xl font-extrabold tracking-wide uppercase text-slate-800">Past Events</h2>
-{% if past.size == 0 %}
-    <p class="mt-4 text-slate-600">No past events yet.</p>
-{% else %}
-    <div class="mt-6 divide-y divide-slate-200 rounded-2xl ring-1 ring-slate-200 bg-white">
-    {% for p in past %}
-        {% assign ev = p.event %}
-        <article class="p-4 md:p-5 grid md:grid-cols-5 gap-3">
-        <p class="text-sm text-slate-500 md:col-span-1">
-            {{ ev.start.dateTime | default: ev.start.date | date: "%b %-d, %Y" }}
-        </p>
-        <div class="md:col-span-3">
-            <a href="{{ p.url | relative_url }}" class="font-semibold hover:underline">
-            {{ ev.summary | default: p.title }}
-            </a>
-            {% if ev.location %}
-              {% if p.layout contains "public" %}
-                <p class="text-sm text-slate-600 mt-0.5">{{ ev.location }}</p>
-              {% else %}
-                <p class="text-sm text-slate-600 mt-0.5">Location available in members calendar</p>
-              {% endif %}
-            {% endif %}
-        </div>
-        <div class="md:col-span-1 flex items-start md:justify-end">
-          <a href="{{ p.url }}" target="_blank" rel="noopener"
-             class="inline-flex items-center rounded-lg px-3 py-1.5 text-sm font-medium
-                    ring-1 ring-slate-300 hover:bg-slate-50">
-            View
-          </a>
-        </div>
-        </article>
-    {% endfor %}
+  <div class="flex items-baseline justify-between flex-wrap gap-2">
+    <h2 class="text-2xl md:text-3xl font-extrabold tracking-wide uppercase text-cub-blue">Calendar</h2>
+    <div class="text-sm text-slate-600 flex items-center gap-4">
+      <span class="inline-flex items-center gap-1.5">
+        <span class="inline-block w-3 h-3 rounded-sm" style="background:#1e3a8a"></span>
+        Pack-wide
+      </span>
+      <span class="inline-flex items-center gap-1.5">
+        <span class="inline-block w-3 h-3 rounded-sm" style="background:#ca8a04"></span>
+        Den / Members
+      </span>
     </div>
-{% endif %}
+  </div>
+
+  {% include calendar-widget.html %}
+
+  <div class="mt-8">
+    <h3 class="text-lg font-bold tracking-wide uppercase text-slate-700">Subscribe in Google Calendar</h3>
+    <p class="mt-2 text-sm text-slate-600">Open any calendar in Google Calendar to subscribe and get updates on your phone.</p>
+
+    <p class="mt-4 text-xs font-semibold uppercase tracking-wide text-slate-500">Pack-wide</p>
+    <div class="mt-2 flex flex-wrap gap-2">
+      {% for cal in site.gcalendar.calendars %}
+        {% if cal.name and cal.layout == 'event-public' %}
+        <a href="https://calendar.google.com/calendar/render?cid={{ cal.id | url_encode }}"
+           target="_blank" rel="noopener noreferrer"
+           class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium ring-1 ring-slate-300 bg-white hover:bg-slate-50">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          {{ cal.name }}
+        </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <p class="mt-5 text-xs font-semibold uppercase tracking-wide text-slate-500">Dens (members only)</p>
+    <div class="mt-2 flex flex-wrap gap-2">
+      {% for cal in site.gcalendar.calendars %}
+        {% if cal.name and cal.layout == 'event-private' %}
+        <a href="https://calendar.google.com/calendar/render?cid={{ cal.id | url_encode }}"
+           target="_blank" rel="noopener noreferrer"
+           class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium ring-1 ring-slate-300 bg-white hover:bg-slate-50">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          {{ cal.name }}
+        </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
 </section>

--- a/events.json
+++ b/events.json
@@ -1,0 +1,35 @@
+---
+layout: null
+permalink: /events.json
+---
+[
+{%- assign events = '' | split: '' -%}
+{%- for p in site.pages -%}
+  {%- if p.url and p.url contains '/events/' and p.event -%}
+    {%- assign events = events | push: p -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- for p in events -%}
+{%- assign ev = p.event -%}
+{%- assign start_iso = ev.start.dateTime | default: ev.start.date -%}
+{%- assign end_iso = ev.end.dateTime | default: ev.end.date -%}
+{%- assign is_all_day = false -%}
+{%- if ev.start.date and ev.start.dateTime == nil -%}{%- assign is_all_day = true -%}{%- endif -%}
+{%- assign is_public = false -%}
+{%- if p.layout contains 'public' -%}{%- assign is_public = true -%}{%- endif -%}
+  {
+    "title": {{ ev.summary | default: p.title | jsonify }},
+    "start": {{ start_iso | jsonify }},
+    {%- if end_iso %}
+    "end": {{ end_iso | jsonify }},
+    {%- endif %}
+    "allDay": {{ is_all_day }},
+    "url": {{ p.url | relative_url | jsonify }},
+    "color": "{% if is_public %}#1e3a8a{% else %}#ca8a04{% endif %}",
+    "extendedProps": {
+      "audience": "{% if is_public %}Pack-wide{% else %}Members{% endif %}"
+      {%- if is_public and ev.location %}, "location": {{ ev.location | jsonify }}{%- endif %}
+    }
+  }{%- unless forloop.last -%},{%- endunless -%}
+{%- endfor -%}
+]

--- a/index.md
+++ b/index.md
@@ -141,7 +141,7 @@ navbarText: Palo Alto, CA
     {%- endif -%}
 
     <div class="mt-8 text-center">
-      <a href="/events/" class="inline-flex items-center px-5 py-3 font-semibold text-white transition rounded-lg bg-slate-900 hover:bg-slate-800">
+      <a href="/calendar/" class="inline-flex items-center px-5 py-3 font-semibold text-white transition rounded-lg bg-slate-900 hover:bg-slate-800">
         Full Calendar
       </a>
     </div>


### PR DESCRIPTION
## Summary
- Replace the upcoming/past event lists at `/calendar/` with an interactive FullCalendar grid (month view + year-long list view), fed by a new Jekyll-generated `/events.json` feed
- Past days and events are visually faded, today is highlighted with a gold pill, event titles wrap with a 2-line ellipsis
- Add a "Subscribe in Google Calendar" section split between Pack-wide and Dens (members only), iterated from `site.gcalendar.calendars` so the list stays in sync with config
- Fix mislabeled calendar in `_config.yml` (the entry labeled Wolf Den actually hosts AoL events — confirmed by inspecting built event data) and add the real Wolf Den calendar
- Point the homepage "Full Calendar" button at `/calendar/` (the old `/events/` target had no index page)

## Test plan
- [ ] Open `/calendar/`, verify month grid renders with events from all five den calendars plus pack-wide
- [ ] Click an event → navigates to its detail page
- [ ] Toggle to List view → shows year-long chronological list
- [ ] Confirm today's date is highlighted, past days are faded
- [ ] Confirm five den subscribe buttons (🦁 Lion, 🐯 Tiger, 🐺 Wolf, 🐻 Bear, 🏹 AoL) open the correct Google Calendar subscribe URL
- [ ] Homepage "Full Calendar" button navigates to `/calendar/`
- [ ] Mobile: initial view defaults to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)